### PR TITLE
Passing boid pointers instead of properties

### DIFF
--- a/Boid.cpp
+++ b/Boid.cpp
@@ -26,7 +26,7 @@ Boid::Boid(int id, sf::RenderWindow *window)
     _sprite = sf::CircleShape(_boidSize);
 }
 
-void Boid::update(Vector2f *pos, Vector2f *vel, BoidType *bt, int size)
+void Boid::update(Boid** boids, int size)
 {
     Vector2f separation;
     Vector2f alignment;
@@ -38,33 +38,33 @@ void Boid::update(Vector2f *pos, Vector2f *vel, BoidType *bt, int size)
 
     // loop through all other boids
     for (int i = 0; i < size; i++)
-    {
-        // get the distance to the boid, skip if the distance is zero
-        float range = VMath::length(_pos - pos[i]);
-        if (range == 0)
+    {   
+        if (boids[i]->getId() == _id)
         {
             continue;
         }
 
+        float range = VMath::length(_pos - boids[i]->getPos());
+
         // act depending on the type of boid
-        switch (bt[i])
+        switch (boids[i]->getBoidType())
         {
         case PREY:
             // Separation
             if (range < _sr)
             {
-                separation += _pos - pos[i];
+                separation += _pos - boids[i]->getPos();
             }
             // Alignment
             if (range < _ar)
             {
-                alignment += vel[i];
+                alignment += boids[i]->getVel();
                 alignmentNeighbours++;
             }
             // Cohesion
             if (range < _cr)
             {
-                cohesion += pos[i];
+                cohesion += boids[i]->getPos();
                 cohesionNeighbours++;
             }
             break;
@@ -72,7 +72,7 @@ void Boid::update(Vector2f *pos, Vector2f *vel, BoidType *bt, int size)
         case PREDATOR:
             if (range < _pr)
             {
-                predator -= _pos - pos[i];
+                predator -= _pos - boids[i]->getPos();
             }
             break;
         }
@@ -121,4 +121,9 @@ void Boid::draw()
 {
     _sprite.setPosition(_pos);
     _window->draw(_sprite);
+}
+
+Boid::~Boid()
+{
+    std::cout << "Deleting boid id " << _id << '\n';
 }

--- a/Boid.h
+++ b/Boid.h
@@ -19,7 +19,7 @@ typedef enum BoidType{
 
 class Boid
 {
-    BoidType bt = PREY;
+    BoidType _bt = PREY;
     Vector2f _pos;
     Vector2f _dir;
     Vector2u _windowDimensions;
@@ -55,11 +55,12 @@ public:
     // General functions
     Vector2f getPos() { return _pos; }
     Vector2f getVel() { return _dir; }
-    BoidType getBoidType() {return bt;}
+    BoidType getBoidType() {return _bt;}
+    int getId() {return _id;}
 
     // inherited functions
-    virtual void update(Vector2f *distances, Vector2f *velocities, BoidType *bt,  int count);
-    // virtual void update(Boid**,  int count);
+    // virtual void update(Vector2f *distances, Vector2f *velocities, BoidType *bt,  int count);
+    virtual void update(Boid** boids,  int count);
     virtual void draw();
 
     // local functions
@@ -68,6 +69,8 @@ public:
     void alignment(Vector2f *dist, Vector2f *vel, int size);
     void cohesion(Vector2f *distances, int count);
     void margins();
+
+    ~Boid();
 };
 
 

--- a/Flock.cpp
+++ b/Flock.cpp
@@ -14,26 +14,11 @@ Flock::Flock(FlockConfig fc, sf::RenderWindow *window)
 
 void Flock::update()
 {
-    Vector2f pos[_size];
-    Vector2f vel[_size];
-    BoidType bt[_size];
-
-    // get position of all boids
-    for (int j = 0; j < _size; j++)
-    {
-        pos[j] = _boids[j]->getPos();
-        vel[j] = _boids[j]->getVel();
-        bt[j] = _boids[j]->getBoidType();
-    }
-
-    // update all boids 
     for (int i = 0; i < _size; i++)
     {
-        _boids[i]->update(pos, vel, bt, _size);
+        _boids[i]->update(_boids, _size);
     }
 }
-
-
 
 Flock::~Flock()
 {


### PR DESCRIPTION
In the previous version the flock class passed each boid an array of  position and velocity vectors. In this version the flock instead passes each boid an array of all the other boids.