### PR TITLE
Addboidkill

### DIFF
--- a/Boid.cpp
+++ b/Boid.cpp
@@ -25,11 +25,6 @@ Boid::Boid(int id, sf::RenderWindow *window)
 
     // give a shape
     _sprite = sf::CircleShape(_boidSize);
-
-    if (_id == 0)
-    {
-        _sprite.setFillColor(sf::Color::Magenta);
-    }
 }
 
 void Boid::update(Boid **boids, int size)
@@ -92,6 +87,8 @@ void Boid::update(Boid **boids, int size)
                 predator -= _pos - boids[i]->getPos();
             }
             break;
+        case DEAD:
+            break;
         }
     }
 
@@ -125,19 +122,6 @@ void Boid::update(Boid **boids, int size)
 
     // move and draw the boid
     draw();
-
-    // if (_id == 0)
-    // {
-    //     dh->drawCircle(_pos, _visualRange, _boidSize);
-    //     dh->drawCircle(_pos, _personalSpace, _boidSize);
-
-    //     float scale = 5000;
-
-    //     dh->drawVelocity(_pos, scale * sv, sf::Color::Blue, _boidSize);
-    //     dh->drawVelocity(_pos, scale * av, sf::Color::Red, _boidSize);
-    //     dh->drawVelocity(_pos, scale * cv, sf::Color::Green, _boidSize);
-    //     dh->drawVelocity(_pos, 100.f * _vel, sf::Color::White, _boidSize);
-    // }
 }
 
 void Boid::margins()

--- a/Boid.cpp
+++ b/Boid.cpp
@@ -29,6 +29,9 @@ Boid::Boid(int id, sf::RenderWindow *window)
 
 void Boid::update(Boid **boids, int size)
 {
+    // if the boid is dead don't do anything
+    if (_bt == DEAD) return;
+
     Vector2f separation;
     Vector2f alignment;
     Vector2f cohesion;
@@ -88,6 +91,7 @@ void Boid::update(Boid **boids, int size)
             }
             break;
         case DEAD:
+            // ignore dead boids
             break;
         }
     }

--- a/Boid.h
+++ b/Boid.h
@@ -15,7 +15,8 @@ using sf::Vector2u;
 
 typedef enum BoidType{
     PREY,
-    PREDATOR
+    PREDATOR,
+    DEAD
 } BoidType;
 
 class Boid
@@ -60,6 +61,7 @@ public:
     Vector2f getVel() { return _vel; }
     BoidType getBoidType() {return _bt;}
     int getId() {return _id;}
+    void kill() {_bt = DEAD;}
 
     // inherited functions
     // virtual void update(Vector2f *distances, Vector2f *velocities, BoidType *bt,  int count);
@@ -67,10 +69,6 @@ public:
     virtual void draw();
 
     // local functions
-    void setDir(Vector2f dir) { _vel = dir; }
-    void separation(Vector2f *distances, int count);
-    void alignment(Vector2f *dist, Vector2f *vel, int size);
-    void cohesion(Vector2f *distances, int count);
     void margins();
 
     ~Boid();


### PR DESCRIPTION
Added behaviour to kill a boid. This changes its boid type to dead, which will immediately return from the update function.

A few other incidental cleanups